### PR TITLE
Changed wiki to docs

### DIFF
--- a/src/scripts/injector.js
+++ b/src/scripts/injector.js
@@ -21,7 +21,7 @@ const components = {
     <a href="/">Home</a>
     <a href="/editor/">Editor</a>
     <a href="https://github.com/mariocraft987/bark.github.io/">Github</a>
-    <br/><br/><a href="https://github.com/mariocraft987/bark-coding/wiki">Wiki</a>
+    <br/><br/><a href="https://bark.dumorando.com/docs">Docs</a>
     <a href="https://discord.gg/hXmHw7H9BF">Discord</a>
     </p></footer>
     `


### PR DESCRIPTION
Hello:)
Because we got a new docs page we should link it instead of the wiki github page